### PR TITLE
Update corpus.py

### DIFF
--- a/src/corporacreator/argparse.py
+++ b/src/corporacreator/argparse.py
@@ -83,7 +83,7 @@ def parse_args(args):
     parser.add_argument(
         "-s",
         "--duplicate-sentence-count",
-        default=1,
+        default=0,
         required=False,
         type=_check_positive,
         help="Maximum number of times a sentence can appear in a corpus.",

--- a/src/corporacreator/corpus.py
+++ b/src/corporacreator/corpus.py
@@ -90,7 +90,10 @@ class Corpus:
             speaker_counts.set_index("client_id"), on="client_id"
         )
         self.validated = self.validated.sort_values(["user_sentence_count", "client_id"])
-        validated = self.validated.groupby("sentence").head(self.args.duplicate_sentence_count)
+        if self.args.duplicate_sentence_count == 0:
+            validated = self.validated.groupby("sentence")
+        else:
+            validated = self.validated.groupby("sentence").head(self.args.duplicate_sentence_count)
 
         validated = validated.sort_values(["user_sentence_count", "client_id"], ascending=False)
         validated = validated.drop(columns="user_sentence_count")


### PR DESCRIPTION
Fixes #113.

The default should be to not be strict with audio.  For people training some models they can use `-s 1`