### PR TITLE
Fix deprecated read_csv option

### DIFF
--- a/src/corporacreator/corpora.py
+++ b/src/corporacreator/corpora.py
@@ -89,7 +89,7 @@ class Corpora:
             parse_dates=False,
             engine="python",
             encoding="utf-8",
-            error_bad_lines=False,
+            on_bad_lines='skip',
             quotechar='"',
             quoting=csv.QUOTE_NONE,
         )


### PR DESCRIPTION
In pd.read_csv(), error_bad_lines option is deprecated and replaced with on_bad_lines 