### PR TITLE
Will invalidate sentences with question mark in the middle

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ setup_requires = pyscaffold>=3.1a0,<3.2a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 install_requires = pandas
                    swifter
+                   regex
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/src/corporacreator/preprocessors/common.py
+++ b/src/corporacreator/preprocessors/common.py
@@ -1,4 +1,5 @@
 import re
+import regex
 import unicodedata
 
 from urllib.parse import unquote
@@ -6,9 +7,17 @@ from html.parser import HTMLParser
 
 
 RE_DIGITS = re.compile('\d')
+QUESTION_BEFORE_LOWERCASE = regex.compile(r'\?\p{Ll}')
+
 
 def _has_digit(sentence):
     return RE_DIGITS.search(sentence)
+
+
+def _has_question_in_middle(sentence):
+    if QUESTION_BEFORE_LOWERCASE.search(sentence):
+        return True
+    return False
 
 
 class _HTMLStripper(HTMLParser):
@@ -92,5 +101,8 @@ def common(sentence):
         is_valid = False
     # If the sentence is blank reject it
     if not sentence.strip():
+        is_valid = False
+    # If sentence has question mark before a lowercase letter it is most likely a case of broken sentence encoding
+    if _has_question_in_middle(sentence):
         is_valid = False
     return (is_valid, sentence)


### PR DESCRIPTION
Adding validation for sentences with question mark before lower case character.

This PR extends comments mentioned in https://github.com/common-voice/CorporaCreator/pull/126

Current code in this PR does not do any special validations for Spanish as it assumes that the regular question mark "?" before lower case character is still invalid for Spanish and valid cases would be use of upside down question mark "¿" or regular question mark "?" before upper case character.

Also as this code marks sentences invalid and does not drop them completely they can still be picked up from the invalidated set if needed.

Happy to adjust the code with more specific checks for Spanish if someone guides me on valid and invalid examples for Spanish 